### PR TITLE
added Video format mapping

### DIFF
--- a/assets/finc/formats/de105.json
+++ b/assets/finc/formats/de105.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Article, E-Article",
     "ElectronicSerial": "Article, E-Article",
     "ElectronicThesis": "Article, E-Article",
-    "Unknown": "Article, E-Article" 
+    "Unknown": "Article, E-Article",
+    "Video": "Video" 
 }

--- a/assets/finc/formats/de14.json
+++ b/assets/finc/formats/de14.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/de520.json
+++ b/assets/finc/formats/de520.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/de540.json
+++ b/assets/finc/formats/de540.json
@@ -16,5 +16,6 @@
     "Map": "Map",
     "Letter": "Letter",
     "Article": "Article, E-Article",
-    "Text": "Text"
+    "Text": "Text",
+    "Video": "Video"
 }

--- a/assets/finc/formats/dech1.json
+++ b/assets/finc/formats/dech1.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/ded117.json
+++ b/assets/finc/formats/ded117.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/degla1.json
+++ b/assets/finc/formats/degla1.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/del152.json
+++ b/assets/finc/formats/del152.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Buch",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/del189.json
+++ b/assets/finc/formats/del189.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/dezi4.json
+++ b/assets/finc/formats/dezi4.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/dezwi2.json
+++ b/assets/finc/formats/dezwi2.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }

--- a/assets/finc/formats/nrw.json
+++ b/assets/finc/formats/nrw.json
@@ -7,5 +7,6 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
-    "Unknown": "Unknown Format"
+    "Unknown": "Unknown Format",
+    "Video": "Video"
 }


### PR DESCRIPTION
I added a mapping for the format "Video" to all other client specific format mappings. The format "Video" is utilized in sources e.g. Lynda [141] or AV-Portal [145].