### PR TITLE
added Norm format mapping

### DIFF
--- a/assets/finc/formats/de105.json
+++ b/assets/finc/formats/de105.json
@@ -7,6 +7,7 @@
     "ElectronicResourceRemoteAccess": "Article, E-Article",
     "ElectronicSerial": "Article, E-Article",
     "ElectronicThesis": "Article, E-Article",
+    "Norm": "Norm",
     "Unknown": "Article, E-Article",
     "Video": "Video" 
 }

--- a/assets/finc/formats/de14.json
+++ b/assets/finc/formats/de14.json
@@ -7,6 +7,7 @@
     "ElectronicResourceRemoteAccess": "Electronic Resource (Remote Access)",
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
+    "Norm": "Norm",
     "Unknown": "Unknown Format",
     "Video": "Video"
 }

--- a/assets/finc/formats/de520.json
+++ b/assets/finc/formats/de520.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/de540.json
+++ b/assets/finc/formats/de540.json
@@ -17,5 +17,6 @@
     "Letter": "Letter",
     "Article": "Article, E-Article",
     "Text": "Text",
-    "Video": "Video"
+    "Video": "Video",
+    "Norm": "Norm"
 }

--- a/assets/finc/formats/dech1.json
+++ b/assets/finc/formats/dech1.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/ded117.json
+++ b/assets/finc/formats/ded117.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/degla1.json
+++ b/assets/finc/formats/degla1.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/del152.json
+++ b/assets/finc/formats/del152.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Buch",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/del189.json
+++ b/assets/finc/formats/del189.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/dezi4.json
+++ b/assets/finc/formats/dezi4.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/dezwi2.json
+++ b/assets/finc/formats/dezwi2.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }

--- a/assets/finc/formats/nrw.json
+++ b/assets/finc/formats/nrw.json
@@ -8,5 +8,6 @@
     "ElectronicSerial": "Journal, E-Journal",
     "ElectronicThesis": "Thesis",
     "Unknown": "Unknown Format",
+    "Norm": "Norm",
     "Video": "Video"
 }


### PR DESCRIPTION
I added a mapping for the format "Norm" to all other client specific format mappings. The format "Norm" is utilized in sources e.g. Perinorm [201].