### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/container/string.go
+++ b/container/string.go
@@ -61,7 +61,7 @@ type StringSet struct {
 	Set map[string]struct{}
 }
 
-// NewString returns an empty string set. XXX: Make the zero value usable.
+// NewStringSet returns an empty string set. XXX: Make the zero value usable.
 func NewStringSet(s ...string) *StringSet {
 	ss := &StringSet{Set: make(map[string]struct{})}
 	for _, item := range s {
@@ -77,7 +77,7 @@ func (set *StringSet) Add(s string) bool {
 	return !found // False if it existed already
 }
 
-// Add adds a set of string to a set.
+// AddAll adds adds a set of string to a set.
 func (set *StringSet) AddAll(s ...string) bool {
 	for _, item := range s {
 		set.Set[item] = struct{}{}

--- a/formats/degruyter/article.go
+++ b/formats/degruyter/article.go
@@ -60,7 +60,7 @@ func (article *Article) Identifiers() (jats.Identifiers, error) {
 	return jats.Identifiers{DOI: doi, URL: locator, ID: id}, nil
 }
 
-// ToInternalSchema converts a jats article into an internal schema.
+// ToIntermediateSchema converts a jats article into an internal schema.
 func (article *Article) ToIntermediateSchema() (*finc.IntermediateSchema, error) {
 	output, err := article.Article.ToIntermediateSchema()
 	if err != nil {

--- a/formats/jats/article.go
+++ b/formats/jats/article.go
@@ -473,7 +473,7 @@ func clipString(s string, length int) string {
 	return s[:length] + "..."
 }
 
-// ToInternalSchema converts a jats article into an internal schema.
+// ToIntermediateSchema converts a jats article into an internal schema.
 // This is a basic implementation, different source might implement their own.
 func (article *Article) ToIntermediateSchema() (*finc.IntermediateSchema, error) {
 	output := finc.NewIntermediateSchema()

--- a/formats/jstor/article.go
+++ b/formats/jstor/article.go
@@ -113,7 +113,7 @@ func (article *Article) ReviewedProduct() string {
 	return ""
 }
 
-// ToInternalSchema converts an article into an internal schema. There are a
+// ToIntermediateSchema converts an article into an internal schema. There are a
 // couple of content-dependent choices here.
 func (article *Article) ToIntermediateSchema() (*finc.IntermediateSchema, error) {
 	output, err := article.Article.ToIntermediateSchema()

--- a/solrutil/review.go
+++ b/solrutil/review.go
@@ -2,7 +2,7 @@ package solrutil
 
 import "fmt"
 
-// AllowedOnly returns an error if facets values contain non-zero values that
+// AllowedKeys returns an error if facets values contain non-zero values that
 // are not explicitly allowed. Used for reviews.
 func (f FacetMap) AllowedKeys(allowed ...string) error {
 	var keys []string


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?