### PR TITLE
crossref: #29537

### DIFF
--- a/formats/crossref/document.go
+++ b/formats/crossref/document.go
@@ -189,12 +189,11 @@ func (doc *Document) Authors() (authors []finc.Author) {
 	return authors
 }
 
-// ID is of the form <kind>-<source-id>-<id-base64-unpadded>
-// We simple map any primary key of the source (preferably a URL)
-// to a safer alphabet. Since the base64 part is not meant to be decoded
-// we drop the padding. It is simple enough to recover the original value.
+// ID is of the form <kind>-<source-id>-<id-base64-unpadded>.
+// Crossref identities should be DOI-based so URL representation changes do
+// not create a second record for the same work.
 func (doc *Document) ID() string {
-	return fmt.Sprintf("ai-%s-%s", SourceID, base64.RawURLEncoding.EncodeToString([]byte(doc.URL)))
+	return fmt.Sprintf("ai-%s-%s", SourceID, base64.RawURLEncoding.EncodeToString([]byte(doc.DOI)))
 }
 
 // PageInfo parses a page specfication in a best effort manner into a PageInfo struct.

--- a/formats/crossref/document_test.go
+++ b/formats/crossref/document_test.go
@@ -2,6 +2,33 @@ package crossref
 
 import "testing"
 
+func TestDocumentIDUsesDOI(t *testing.T) {
+	doc := &Document{
+		DOI: "10.1038/jid.2009.354",
+		URL: "http://dx.doi.org/10.1038/jid.2009.354",
+	}
+
+	want := "ai-49-MTAuMTAzOC9qaWQuMjAwOS4zNTQ"
+	if got := doc.ID(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDocumentIDIgnoresURLRepresentation(t *testing.T) {
+	a := &Document{
+		DOI: "10.1038/jid.2009.354",
+		URL: "http://dx.doi.org/10.1038/jid.2009.354",
+	}
+	b := &Document{
+		DOI: "10.1038/jid.2009.354",
+		URL: "https://doi.org/10.1038/jid.2009.354",
+	}
+
+	if a.ID() != b.ID() {
+		t.Fatalf("expected same ID for same DOI, got %q and %q", a.ID(), b.ID())
+	}
+}
+
 func TestDocumentCombinedTitle(t *testing.T) {
 	var cases = []struct {
 		about  string


### PR DESCRIPTION
The `id` for Crossref records is currently generated by using the `URL` field. To prevent large identifier changes we should switch to the `DOI` field as it is the primary identifier of work records in Crossref and other than the `URL` won't change.